### PR TITLE
Two improvements to visualization in the docking demo

### DIFF
--- a/docking_demo.py
+++ b/docking_demo.py
@@ -12,6 +12,7 @@ from hello_helpers import hello_misc as hm
 import argparse
 import loop_timer as lt
 import pprint as pp
+from image_processing_helpers import fit_image_to_screen
 
 def compute_visual_servoing_features(center_xyz, midline_xyz, camera_info):
     if (center_xyz is None) or (midline_xyz is None):
@@ -426,7 +427,7 @@ def main(exposure):
                 pp.pprint(cmd)
                 controller.set_command(cmd)
 
-            cv2.imshow('Features Used for Visual Servoing', color_image)
+            cv2.imshow('Features Used for Visual Servoing', fit_image_to_screen(color_image))
             cv2.waitKey(1)
 
             loop_timer.end_of_iteration()

--- a/docking_demo.py
+++ b/docking_demo.py
@@ -215,7 +215,7 @@ def move_to_initial_pose(robot):
     robot.wait_command()
         
 
-def main(exposure):
+def main(exposure, noviz=False):
 
     try:
         pix_per_m_av = None
@@ -427,8 +427,9 @@ def main(exposure):
                 pp.pprint(cmd)
                 controller.set_command(cmd)
 
-            cv2.imshow('Features Used for Visual Servoing', fit_image_to_screen(color_image))
-            cv2.waitKey(1)
+            if not noviz:
+                cv2.imshow('Features Used for Visual Servoing', fit_image_to_screen(color_image))
+                cv2.waitKey(1)
 
             loop_timer.end_of_iteration()
             if print_timing: 
@@ -445,11 +446,13 @@ if __name__ == '__main__':
         description='This application provides a demonstration of using visual servoing to autonomously dock with the official Hello Robot docking station.')
 
     parser.add_argument('-e', '--exposure', action='store', type=str, default='auto', help=f'Set the D435 exposure to {dh.exposure_keywords} or an integer in the range {dh.exposure_range}') 
-    
+    parser.add_argument('-n', '--noviz', nargs='?', default=False, const=True)
+
     args = parser.parse_args()
     exposure = args.exposure
+    noviz = args.noviz
 
     if not dh.exposure_argument_is_valid(exposure):
         raise argparse.ArgumentTypeError(f'The provided exposure setting, {exposure}, is not a valide keyword, {dh.exposure_keywords}, or is outside of the allowed numeric range, {dh.exposure_range}.')    
     
-    main(exposure)
+    main(exposure, noviz)

--- a/image_processing_helpers.py
+++ b/image_processing_helpers.py
@@ -1,0 +1,30 @@
+import os
+from Xlib import display
+import cv2
+
+# Set the DISPLAY environment variable if not already set
+if 'DISPLAY' not in os.environ:
+    os.environ['DISPLAY'] = ':0'
+
+def get_screen_resolution():
+    screen = display.Display().screen()
+    width = screen.width_in_pixels
+    height = screen.height_in_pixels
+    return width, height
+
+def fit_image_to_screen(img: cv2.typing.MatLike, ratio: float=0.75) -> cv2.typing.MatLike:
+    """
+    Resizes an image to fit the screen resolution.
+
+    Args:
+        img (MatLike): The image to resize.
+        ratio (float): The ratio of the screen resolution to use for resizing the image.
+
+    Returns:
+        MatLike: The resized image.
+    """
+
+    screen_width, screen_height = get_screen_resolution()
+    img_width = int(ratio * screen_width)
+    img_height = int(ratio * screen_height)
+    return cv2.resize(img, [img_width, img_height])


### PR DESCRIPTION
Two improvements to visualization in the docking demo:

1. Calling `cv2.imshow` with an image directly implicitly sets the resolution of the window in which the image is displayed. Often on smaller screens, the window is partially off-screen. A helper method is used to resize the image (and thus the window) to fit on screen.
2. A `--noviz` argument is added to the docking_demo.py CLI arguments. The demo runs without showing any visualization when this argument is added.

Testing
----------
Checkout this branch and launch the demo using `python docking_demo.py`. The visualization window should fit on screen without any part of it going off screen.

Run `python docking_demo.py -n` and the visualization window should not appear.