### PR TITLE
Print statistics on exit

### DIFF
--- a/docking_demo.py
+++ b/docking_demo.py
@@ -458,6 +458,7 @@ def main(exposure, noviz=False):
         print(f"  Time: {time.time() - start_time} seconds")
         print(f"  Voltage: {np.mean(power_history['voltage'])} V")
         print(f"  Current: {np.mean(power_history['current'])} A")
+        print(f"  Temperature: {np.mean(power_history['temperature'])} °C")
         print(f"  Charge Current: {np.mean(power_history['charge_current'])} A")
         print(f"  Is Charger Connected: {power_history['charger_connected']}")
         print(f"  Is Charger Charging: {power_history['charger_is_charging']}")

--- a/docking_demo.py
+++ b/docking_demo.py
@@ -224,7 +224,17 @@ def main(exposure, noviz=False):
         camera = dc.D435i(exposure=exposure)
 
         time.sleep(1.0)
-        
+
+        start_time = time.time()
+        power_history = {
+            'voltage': [],
+            'current': [],
+            'temperature': [],
+            'charge_current': [],
+            'charger_connected': None,
+            'charger_is_charging': None,
+        }
+
         robot = rb.Robot()
         robot.startup()
         move_to_initial_pose(robot)
@@ -427,6 +437,14 @@ def main(exposure, noviz=False):
                 pp.pprint(cmd)
                 controller.set_command(cmd)
 
+            # collect power statistics
+            power_history['voltage'].append(robot.pimu.status['voltage'])
+            power_history['current'].append(robot.pimu.status['current'])
+            power_history['temperature'].append(robot.pimu.status['temp'])
+            power_history['charge_current'].append(robot.pimu.status['current_charge'])
+            power_history['charger_connected'] = robot.pimu.status['charger_connected']
+            power_history['charger_is_charging'] = robot.pimu.status['charger_is_charging']
+
             if not noviz:
                 cv2.imshow('Features Used for Visual Servoing', fit_image_to_screen(color_image))
                 cv2.waitKey(1)
@@ -436,7 +454,13 @@ def main(exposure, noviz=False):
                 loop_timer.pretty_print()
 
     finally:
-
+        print("Statistics:")
+        print(f"  Time: {time.time() - start_time} seconds")
+        print(f"  Voltage: {np.mean(power_history['voltage'])} V")
+        print(f"  Current: {np.mean(power_history['current'])} A")
+        print(f"  Charge Current: {np.mean(power_history['charge_current'])} A")
+        print(f"  Is Charger Connected: {power_history['charger_connected']}")
+        print(f"  Is Charger Charging: {power_history['charger_is_charging']}")
         robot.stop()
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR changes docking demo to print statistics on exit, like:

- total time
- avg voltage
- avg current
- avg temp
- and other charge state info

Testing
---------
Check out this branch and launch the demo using `python docking_demo.py`. When the program ends, or you Ctrl + C out of the program, you should see the following printed out (sometimes an exception from a separate thread will print out afterwards, but as long as the statistics is printed out, the test has passed).

![Screenshot from 2024-10-22 13-37-24](https://github.com/user-attachments/assets/b9b05b70-5930-4b0e-b169-4c78525f0140)

Merging
----------

Wait for #1 to merge before merging this PR.